### PR TITLE
Update node version in .nvmrc from 12 to 16

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-12.16.1
+lts/gallium


### PR DESCRIPTION
## Description

This PR does the following:

- Update the version of node used in `.nvmrc` from 12 to 16
- Update the version of node used in the GitHub actions workflow from 12 to 16